### PR TITLE
handle non-existant stacks

### DIFF
--- a/lib/murk/model/stack.rb
+++ b/lib/murk/model/stack.rb
@@ -130,7 +130,7 @@ module Murk
 
       def describe
         stacks = APICache.get("stack_#{qualified_name}", cache: 10, valid: 30, period: 30) do
-          cloudformation.describe_stacks(stack_name: qualified_name)[:stacks]
+          cloudformation.describe_stacks.stacks.select { |s| s if s.stack_name == qualified_name }
         end
         stacks || []
       end


### PR DESCRIPTION
fixing bug where murk tries to get all stack information and fails to find stacks (describe_stacks throws an exception when a stack with name or ID is not found) 

@snoremac @srbartlett please review
